### PR TITLE
Release v2.4.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/react-native-actionsheet",
-  "version": "2.4.2",
+  "version": "2.4.3",
   "description": "Cross platform ActionSheet. This component implements a custom ActionSheet  and provides the same way to drawing it on the defferent platforms(iOS and Android). Actually, In order to keep the best effect, it still uses the ActionSheetIOS on iOS.",
   "main": "lib/index.js",
   "scripts": {


### PR DESCRIPTION
This is the release candidate of `@metamask/react-native-actionsheet` v2.4.3.

---

Changes since v2.4.2:
- #6